### PR TITLE
Added VLS EP boxes to separate vls SyncUnit 

### DIFF
--- a/plc-tmo-vac/_Config/IO/Device 1 (EtherCAT).xti
+++ b/plc-tmo-vac/_Config/IO/Device 1 (EtherCAT).xti
@@ -113,6 +113,7 @@
 		</Box>
 		<EtherCAT EnableVirtualSwitch="true" MaxSwitchPorts="4" MaxSwitchFrames="160">
 			<SyncUnit Name="IP1_ECAT (EL6692)" NoDeleteIfUnused="true"/>
+			<SyncUnit Name="vls" NoDeleteIfUnused="true"/>
 		</EtherCAT>
 	</Device>
 </TcSmItem>


### PR DESCRIPTION
Since VLS has been decabled and taken out of the beamline, I put the VLS EP boxes in a separate sync unit so that the rest of the TMO vacuum solution can run. Once this was done the solution ran and the TMO beamline vacuum came back.

In the near future, the VLS PRGs and GVLs may be removed or commented out as well.